### PR TITLE
Fix typo in trainjob tests

### DIFF
--- a/pkg/util/trainjob/trainjob_test.go
+++ b/pkg/util/trainjob/trainjob_test.go
@@ -48,7 +48,7 @@ func TestRuntimeRefIsTrainingRuntime(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := RuntimeRefIsTrainingRuntime(tc.ref)
 			if got != tc.want {
-				t.Errorf("Unexpected RuntimeRefIsTrainingRuntime()\nwant: %v\n, want: %v", got, tc.want)
+				t.Errorf("Unexpected RuntimeRefIsTrainingRuntime()\nwant: %v\n got: %v", tc.want, got)
 			}
 		})
 	}
@@ -78,7 +78,7 @@ func TestRuntimeRefIsClusterTrainingRuntime(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := RuntimeRefIsClusterTrainingRuntime(tc.ref)
 			if got != tc.want {
-				t.Errorf("Unexpected RuntimeRefIsClusterTrainingRuntime()\nwant: %v\n, want: %v", got, tc.want)
+				t.Errorf("Unexpected RuntimeRefIsClusterTrainingRuntime()\nwant: %v\n got: %v", tc.want, got)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- correct formatting in trainjob error messages

## Testing
- `go test ./...` *(fails: unable to start controlplane – fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6844b46c7380832daad9d47ba5c62760